### PR TITLE
Global library tweaks

### DIFF
--- a/openshift/s2i-nginx-builder-bc.json
+++ b/openshift/s2i-nginx-builder-bc.json
@@ -10,7 +10,7 @@
                 "name": "base-centos7",
                 "creationTimestamp": null,
                 "labels": {
-                    "build": "s2i-nginx"
+                    "build": "bcgov-s2i-nginx"
                 },
                 "annotations": {
                     "openshift.io/generated-by": "OpenShiftNewBuild"
@@ -40,10 +40,10 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "s2i-nginx",
+                "name": "bcgov-s2i-nginx",
                 "creationTimestamp": null,
                 "labels": {
-                    "build": "s2i-nginx"
+                    "build": "bcgov-s2i-nginx"
                 },
                 "annotations": {
                     "openshift.io/generated-by": "OpenShiftNewBuild"
@@ -58,10 +58,10 @@
             "kind": "BuildConfig",
             "apiVersion": "v1",
             "metadata": {
-                "name": "s2i-nginx",
+                "name": "bcgov-s2i-nginx",
                 "creationTimestamp": null,
                 "labels": {
-                    "build": "s2i-nginx"
+                    "build": "bcgov-s2i-nginx"
                 },
                 "annotations": {
                     "openshift.io/generated-by": "OpenShiftNewBuild"
@@ -95,7 +95,7 @@
                 "output": {
                     "to": {
                         "kind": "ImageStreamTag",
-                        "name": "s2i-nginx:latest"
+                        "name": "bcgov-s2i-nginx:latest"
                     }
                 },
                 "resources": {},

--- a/openshift/s2i-nginx-builder-bc.json
+++ b/openshift/s2i-nginx-builder-bc.json
@@ -1,0 +1,109 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "base-centos7",
+                "creationTimestamp": null,
+                "labels": {
+                    "build": "s2i-nginx"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewBuild"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/imported-from": "openshift/base-centos7"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "openshift/base-centos7"
+                        },
+                        "generation": null,
+                        "importPolicy": {}
+                    }
+                ]
+            },
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "s2i-nginx",
+                "creationTimestamp": null,
+                "labels": {
+                    "build": "s2i-nginx"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewBuild"
+                }
+            },
+            "spec": {},
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "s2i-nginx",
+                "creationTimestamp": null,
+                "labels": {
+                    "build": "s2i-nginx"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewBuild"
+                }
+            },
+            "spec": {
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "type": "ImageChange",
+                        "imageChange": {}
+                    }
+                ],
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "https://github.com/BCDevOps/s2i-nginx.git"
+                    }
+                },
+                "strategy": {
+                    "type": "Docker",
+                    "dockerStrategy": {
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "base-centos7:latest"
+                        }
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "s2i-nginx:latest"
+                    }
+                },
+                "resources": {},
+                "postCommit": {}
+            },
+            "status": {
+                "lastVersion": 0
+            }
+        }
+    ]
+}

--- a/openshift/templates/nginx-build-template.json
+++ b/openshift/templates/nginx-build-template.json
@@ -2,7 +2,7 @@
     "kind": "Template",
     "apiVersion": "v1",
     "metadata": {
-        "name": "nginx",
+        "name": "nginx-reverse-proxy-build",
         "creationTimestamp": null
     },
     "objects": [
@@ -51,12 +51,14 @@
                     "git": {
                         "ref": "${SOURCE_REPOSITORY_REF}",
                         "uri": "${SOURCE_REPOSITORY_URL}"
-                    }
+                    },
+                    "contextDir": "${CONTEXT_DIR}"
                 },
                 "strategy": {
                     "type": "Source",
                     "sourceStrategy": {
                         "from": {
+                            "namespace": "${BUILDER_IMAGESTREAM_NAMESPACE}",
                             "kind": "ImageStreamTag",
                             "name": "${BUILDER_IMAGESTREAM_TAG}"
                         },
@@ -87,12 +89,21 @@
       "displayName": "Name",
       "description": "The name assigned to all of the frontend objects defined in this template.",
       "required": true,
-      "value": "nginx"
+      "value": "nginx-reverse-proxy"
     },
     {
       "name": "BUILDER_IMAGESTREAM_TAG",
       "displayName": "Builder ImageStreamTag",
-      "description": "The image stream tag (e.g. rproxy:latest) of the S2I image that should be used to build the application."
+      "description": "The image stream tag (e.g. rproxy:latest) of the S2I image that should be used to build the application.",
+      "required": true,
+      "value": "s2i-nginx:latest"
+    },
+    {
+      "name": "BUILDER_IMAGESTREAM_NAMESPACE",
+      "displayName": "Builder ImageStream Namespace",
+      "description": "The namespace containing the image stream tag (e.g. rproxy:latest) of the S2I image that should be used to build the application.",
+      "required": true,
+      "value": "openshift"
     },
     {
       "name": "SOURCE_REPOSITORY_URL",
@@ -104,6 +115,12 @@
       "name": "SOURCE_REPOSITORY_REF",
       "displayName": "Git Reference",
       "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+    },
+    {
+      "name": "CONTEXT_DIR",
+      "displayName": "Configuration files path (Context Dir)",
+      "description": "Set this to the path where NGINX files are located within the GitHub repo.",
+      "required": false
     },
     {
       "name": "GITHUB_WEBHOOK_SECRET",

--- a/openshift/templates/nginx-build-template.json
+++ b/openshift/templates/nginx-build-template.json
@@ -96,7 +96,7 @@
       "displayName": "Builder ImageStreamTag",
       "description": "The image stream tag (e.g. rproxy:latest) of the S2I image that should be used to build the application.",
       "required": true,
-      "value": "s2i-nginx:latest"
+      "value": "bcgov-s2i-nginx:latest"
     },
     {
       "name": "BUILDER_IMAGESTREAM_NAMESPACE",

--- a/openshift/templates/nginx-build-template.json
+++ b/openshift/templates/nginx-build-template.json
@@ -1,88 +1,91 @@
 {
-    "kind": "Template",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "nginx-reverse-proxy-build",
-        "creationTimestamp": null
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nginx-reverse-proxy-build",
+    "annotations": {
+      "tags": "bcgov,nginx"
+    }
+  },
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}"
+      }
     },
-    "objects": [
-      {
-        "kind": "ImageStream",
-        "apiVersion": "v1",
-        "metadata": {
-          "name": "${NAME}"
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "creationTimestamp": null,
+        "labels": {
+          "app": "${NAME}"
         }
       },
-      {
-            "kind": "BuildConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}",
-                "creationTimestamp": null,
-                "labels": {
-                    "app": "${NAME}"
-                }
-            },
-            "spec": {
-                "triggers": [
-                    {
-                        "type": "GitHub",
-                        "github": {
-                            "secret": "${GITHUB_WEBHOOK_SECRET}"
-                        }
-                    },
-                    {
-                        "type": "Generic",
-                        "generic": {
-                            "secret": "${GENERIC_WEBHOOK_SECRET}"
-                        }
-                    },
-                    {
-                        "type": "ConfigChange"
-                    },
-                    {
-                        "type": "ImageChange",
-                        "imageChange": {}
-                    }
-                ],
-                "runPolicy": "Serial",
-                "source": {
-                    "type": "Git",
-                    "git": {
-                        "ref": "${SOURCE_REPOSITORY_REF}",
-                        "uri": "${SOURCE_REPOSITORY_URL}"
-                    },
-                    "contextDir": "${CONTEXT_DIR}"
-                },
-                "strategy": {
-                    "type": "Source",
-                    "sourceStrategy": {
-                        "from": {
-                            "namespace": "${BUILDER_IMAGESTREAM_NAMESPACE}",
-                            "kind": "ImageStreamTag",
-                            "name": "${BUILDER_IMAGESTREAM_TAG}"
-                        },
-                        "env": [
-                        {
-                          "name": "NGINX_PROXY_URL",
-                          "value": "${NGINX_PROXY_URL}"
-                        }]
-                    }
-                },
-                "output": {
-                    "to": {
-                        "kind": "ImageStreamTag",
-                        "name": "${NAME}:latest"
-                    }
-                },
-                "resources": {},
-                "postCommit": {}
-            },
-            "status": {
-                "lastVersion": 0
+      "spec": {
+        "triggers": [
+          {
+            "type": "GitHub",
+            "github": {
+              "secret": "${GITHUB_WEBHOOK_SECRET}"
             }
-        }
-    ],
+          },
+          {
+            "type": "Generic",
+            "generic": {
+              "secret": "${GENERIC_WEBHOOK_SECRET}"
+            }
+          },
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChange": {}
+          }
+        ],
+        "runPolicy": "Serial",
+        "source": {
+          "type": "Git",
+          "git": {
+            "ref": "${SOURCE_REPOSITORY_REF}",
+            "uri": "${SOURCE_REPOSITORY_URL}"
+          },
+          "contextDir": "${CONTEXT_DIR}"
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "namespace": "${BUILDER_IMAGESTREAM_NAMESPACE}",
+              "kind": "ImageStreamTag",
+              "name": "${BUILDER_IMAGESTREAM_TAG}"
+            },
+            "env": [
+              {
+                "name": "NGINX_PROXY_URL",
+                "value": "${NGINX_PROXY_URL}"
+              }
+            ]
+          }
+        },
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}:latest"
+          }
+        },
+        "resources": {},
+        "postCommit": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    }
+  ],
   "parameters": [
     {
       "name": "NAME",

--- a/openshift/templates/nginx-deployment-template.json
+++ b/openshift/templates/nginx-deployment-template.json
@@ -2,7 +2,10 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "nginx-reverse-proxy-deployment"
+    "name": "nginx-reverse-proxy-deployment",
+    "annotations": {
+      "tags": "bcgov,nginx"
+    }
   },
   "objects": [
     {

--- a/openshift/templates/nginx-deployment-template.json
+++ b/openshift/templates/nginx-deployment-template.json
@@ -2,8 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "true",
-    "creationTimestamp": null
+    "name": "nginx-reverse-proxy-deployment"
   },
   "objects": [
     {
@@ -157,7 +156,7 @@
     {
       "name": "APPLICATION_DOMAIN",
       "displayName": "Application Hostname",
-      "description": "The exposed hostname that will route to the MyGovBC service, if left blank a value will be defaulted.",
+      "description": "The exposed hostname for the application/service.",
       "required": true
     },
     {


### PR DESCRIPTION
Some modifications to templates to make them more usable/intuitive when being used from the global library, as well as addition of a build config so that the s2i-builder-image can be built in OpenShift (to support the templates).

The net of this is that users will be able to create their own NGINX containers from a template (e.g. "Add to Project" in UI), and *without* building the builder image themselves.  Also, they will be able to create a deployment of the image they build using a template.

These templates are already available in the global library.