### PR TITLE
Only substitute existing environment variables with envsubst

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -15,8 +15,7 @@ envsubst_config() {
     echo "---> substituting environment variables in templates"
     for file in /opt/app-root/etc/nginx.conf.d/*.tmpl; do
       target_file="/opt/app-root/etc/nginx.conf.d/$(basename "$file" .tmpl)"
-      envsubst < "$file" > "$target_file"
-    done
+      envsubst "`printf '${%s} ' $(bash -c "compgen -A variable")`" < "$file" > "$target_file"    done
   fi
 }
 


### PR DESCRIPTION
This PR lets you use nginx variables prefaced with the `$` symbol as long as there isn't an environment variable with the same name.